### PR TITLE
Improved Chat Functionalities

### DIFF
--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -17,7 +17,6 @@ const allUsers = firebase.database().ref("users");
 const MESSAGE = "message";
 const USER = "user";
 
-
 class RoomService {
   private rootRef: firebase.database.Reference;
   private messageRef: firebase.database.Reference;

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -44,10 +44,7 @@ class RoomService {
     this.messageRef.on("child_added", (data: any) => {
       if (!data) throw new Error("Messages should never be null");
       const val = data.val();
-      this.getUser(val.fromID)
-        .then((userFrom) => {
-          onMessagePosted(val.data, userFrom);
-        });
+      onMessagePosted(val.data, val.fromID);
     });
     this.messageRef.on("child_changed", (data: any) => {
       throw new Error("Messages should never changed");

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -82,29 +82,6 @@ class RoomService implements IRoomService {
     });
   }
 
-  public getUser(userID: string): Promise<void> {
-    return this.getDataAtReference(allUsers.child(userID));
-  }
-
-  public getMySelf(): Promise<void> {
-    return this.getDataAtReference(this.myself);
-  }
-
-  public updateConf(confData: any): void {
-    this.myself.update(confData);
-  }
-
-  public setConf(confData: any): void {
-    this.myself.set(confData);
-  }
-
-  private getDataAtReference(reference: firebase.database.Reference): Promise<void> {
-    return new Promise<void>((resolve) => {
-      this.myself.once("value", (data) => {
-        resolve(data.val());
-      });
-    });
-  }
 }
 
 export default RoomService;

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -1,4 +1,5 @@
 import * as firebase from "firebase";
+import {IRoomService} from "../client/backgroundContext";
 
 // Initialize Firebase
 const config = {
@@ -17,7 +18,7 @@ const allUsers = firebase.database().ref("users");
 const MESSAGE = "message";
 const USER = "user";
 
-class RoomService {
+class RoomService implements IRoomService {
   private rootRef: firebase.database.Reference;
   private messageRef: firebase.database.Reference;
   private myself: firebase.database.Reference;
@@ -97,7 +98,7 @@ class RoomService {
     this.myself.set(confData);
   }
 
-  public getDataAtReference(reference: firebase.database.Reference): Promise<any> {
+  private getDataAtReference(reference: firebase.database.Reference): Promise<any> {
     return new Promise<any>((resolve) => {
       this.myself.once("value", (data) => {
         resolve(data.val());

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -21,6 +21,7 @@ const USER = "user";
 class RoomService implements IRoomService {
   private rootRef: firebase.database.Reference;
   private messageRef: firebase.database.Reference;
+  private userListRef: firebase.database.Reference;
   private myself: firebase.database.Reference;
   private active: boolean;
 
@@ -54,7 +55,8 @@ class RoomService implements IRoomService {
     });
 
     // set up configRef
-    this.rootRef.child(USER).child(this.id).set(true);
+    this.userListRef = this.rootRef.child(USER);
+    this.userListRef.child(this.id).set(true);
     this.myself = allUsers.child(this.id);
     this.active = true;
   }
@@ -62,9 +64,9 @@ class RoomService implements IRoomService {
   public close(): void {
     if (this.active) {
       this.messageRef.off();
-      this.rootRef.child(USER).child(this.id).remove()
+      this.userListRef.child(this.id).remove()
         .then(() => {
-          this.rootRef.child(USER).once("value", (data) => {
+          this.userListRef.once("value", (data) => {
             if (!data.val()) {
               this.rootRef.remove();
             }

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -29,7 +29,7 @@ class RoomService implements IRoomService {
     this.active = false;
   }
 
-  public setUrl(url: string, onMessagePosted: (data: any, from: any) => void) {
+  public setUrl(url: string, onMessagePosted: (data: any) => void) {
     this.close();
 
     const cleanUrl = url.replace(/[\\.]/g, ",")
@@ -45,7 +45,7 @@ class RoomService implements IRoomService {
     this.messageRef.on("child_added", (data: any) => {
       if (!data) throw new Error("Messages should never be null");
       const val = data.val();
-      onMessagePosted(val.data, val.fromID);
+      onMessagePosted(val);
     });
     this.messageRef.on("child_changed", (data: any) => {
       throw new Error("Messages should never changed");
@@ -78,10 +78,7 @@ class RoomService implements IRoomService {
 
   public pushMessage(data: any): void {
     if (!data) throw new Error(`data is {data}`);
-    this.messageRef.push().set({
-      data,
-      fromID: this.id
-    });
+    this.messageRef.push().set(data);
   }
 
 }

--- a/component/background/RoomService.tsx
+++ b/component/background/RoomService.tsx
@@ -82,11 +82,11 @@ class RoomService implements IRoomService {
     });
   }
 
-  public getUser(userID: string): Promise<any> {
+  public getUser(userID: string): Promise<void> {
     return this.getDataAtReference(allUsers.child(userID));
   }
 
-  public getMySelf(): Promise<any> {
+  public getMySelf(): Promise<void> {
     return this.getDataAtReference(this.myself);
   }
 
@@ -98,8 +98,8 @@ class RoomService implements IRoomService {
     this.myself.set(confData);
   }
 
-  private getDataAtReference(reference: firebase.database.Reference): Promise<any> {
-    return new Promise<any>((resolve) => {
+  private getDataAtReference(reference: firebase.database.Reference): Promise<void> {
+    return new Promise<void>((resolve) => {
       this.myself.once("value", (data) => {
         resolve(data.val());
       });

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -60,7 +60,7 @@ class StorageService {
    * @param key The key to remove
    * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the key is removed
    */
-  public remove(key): Promise<{}> {
+  public remove(key: string): Promise<{}> {
     return new Promise((resolve) => {
       this.storage.remove(key, resolve);
     });
@@ -69,10 +69,10 @@ class StorageService {
   /**
    * Subscribes a callback to an onChanged event.
    * @param callback function that takes one parameter of data.
-     @return zero argument function that will unsubscribe the callback.
+   * @return  zero argument function that will unsubscribe the callback.
    */
   public subscribe(callback) {
-    const syncListener = (data, area: string) => {
+    const syncListener = (data: object, area: string) => {
       if (area === this.STORAGE_TYPE) {
         callback(data);
       }
@@ -82,7 +82,7 @@ class StorageService {
 
     const unsubscriber = () => {
       chrome.storage.onChanged.removeListener(syncListener);
-    }
+    };
 
     return unsubscriber;
   }

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -1,4 +1,5 @@
 import {STORAGE_KEY_ID} from "../client/Constants";
+import {IStorageService} from "../client/backgroundContext";
 
 class StorageService {
   private storage: chrome.storage.StorageArea;
@@ -13,9 +14,9 @@ class StorageService {
 
   /**
    * Clear the storage space and load with default settings
-   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after defaults are set
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after defaults are set
    */
-  public reset(): Promise<{}> {
+  public reset(): Promise<any> {
     return new Promise((resolve) => {
       this.storage.get(STORAGE_KEY_ID, (data) => {
         this.storage.clear(() => {
@@ -42,9 +43,9 @@ class StorageService {
    * Sets the key-value in the storage
    * @param key The key
    * @param value The value
-   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the value is set
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the value is set
    */
-  public set(key: string, value: string): Promise<{}> {
+  public set(key: string, value: string): Promise<any> {
     const data = {};
     data[key] = value;
 
@@ -56,9 +57,9 @@ class StorageService {
   /**
    * Removes the key (and its associated value) from the storage
    * @param key The key to remove
-   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the key is removed
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the key is removed
    */
-  public remove(key): Promise<{}> {
+  public remove(key): Promise<any> {
     return new Promise((resolve) => {
       this.storage.remove(key, resolve);
     });

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -1,9 +1,10 @@
 import {IStorageService} from "../client/backgroundContext";
 import {STORAGE_KEY_ID} from "../client/Constants";
 
+const STORAGE_TYPE = "sync";
+
 class StorageService {
   private storage: chrome.storage.StorageArea;
-  private STORAGE_TYPE: string = "sync";
 
   constructor() {
     this.storage = chrome.storage.sync;
@@ -73,7 +74,7 @@ class StorageService {
    */
   public subscribe(callback): () => void {
     const syncListener = (data: object, area: string) => {
-      if (area === this.STORAGE_TYPE) {
+      if (area === STORAGE_TYPE) {
         callback(data);
       }
     };

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -1,5 +1,5 @@
-import {STORAGE_KEY_ID} from "../client/Constants";
 import {IStorageService} from "../client/backgroundContext";
+import {STORAGE_KEY_ID} from "../client/Constants";
 
 class StorageService {
   private storage: chrome.storage.StorageArea;

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -71,7 +71,7 @@ class StorageService {
    * @param callback function that takes one parameter of data.
    * @return  zero argument function that will unsubscribe the callback.
    */
-  public subscribe(callback) {
+  public subscribe(callback): () => void {
     const syncListener = (data: object, area: string) => {
       if (area === this.STORAGE_TYPE) {
         callback(data);

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -3,6 +3,7 @@ import {STORAGE_KEY_ID} from "../client/Constants";
 
 class StorageService {
   private storage: chrome.storage.StorageArea;
+  private STORAGE_TYPE: string = "sync";
 
   constructor() {
     this.storage = chrome.storage.sync;
@@ -67,18 +68,23 @@ class StorageService {
 
   /**
    * Subscribes a callback to an onChanged event.
-   * @param callback The function that takes one parameter of data.
+   * @param callback function that takes one parameter of data.
+     @return zero argument function that will unsubscribe the callback.
    */
-  public subscribe(callback): void {
-    chrome.storage.onChanged.addListener(callback);
-  }
+  public subscribe(callback) {
+    const syncListener = (data, area: string) => {
+      if (area === this.STORAGE_TYPE) {
+        callback(data);
+      }
+    };
 
-  /**
-   * Unsubscribes a callback from the onChanged event.
-   * @param callback The function that takes one parameter of data.
-   */
-  public unsubscribe(callback): void {
-    chrome.storage.onChanged.removeListener(callback);
+    chrome.storage.onChanged.addListener(syncListener);
+
+    const unsubscriber = () => {
+      chrome.storage.onChanged.removeListener(syncListener);
+    }
+
+    return unsubscriber;
   }
 
   /*

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -14,9 +14,9 @@ class StorageService {
 
   /**
    * Clear the storage space and load with default settings
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after defaults are set
+   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after defaults are set
    */
-  public reset(): Promise<any> {
+  public reset(): Promise<{}> {
     return new Promise((resolve) => {
       this.storage.get(STORAGE_KEY_ID, (data) => {
         this.storage.clear(() => {
@@ -43,9 +43,9 @@ class StorageService {
    * Sets the key-value in the storage
    * @param key The key
    * @param value The value
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the value is set
+   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the value is set
    */
-  public set(key: string, value: string): Promise<any> {
+  public set(key: string, value: string): Promise<{}> {
     const data = {};
     data[key] = value;
 
@@ -57,9 +57,9 @@ class StorageService {
   /**
    * Removes the key (and its associated value) from the storage
    * @param key The key to remove
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the key is removed
+   * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the key is removed
    */
-  public remove(key): Promise<any> {
+  public remove(key): Promise<{}> {
     return new Promise((resolve) => {
       this.storage.remove(key, resolve);
     });

--- a/component/background/StorageService.tsx
+++ b/component/background/StorageService.tsx
@@ -31,7 +31,7 @@ class StorageService {
    * @param key The key to look up
    * @return {Promise<String>} The value associated with the key; undefined if not found
    */
-  public get(key: string): Promise<string> {
+  public get(key: string): Promise<any> {
     return new Promise((resolve) => {
       this.storage.get(key, (item) => {
         resolve(item[key]);
@@ -45,7 +45,7 @@ class StorageService {
    * @param value The value
    * @return {Promise<{}>} A promise whose resolve takes no argument, which runs after the value is set
    */
-  public set(key: string, value: string): Promise<{}> {
+  public set(key: string, value: any): Promise<{}> {
     const data = {};
     data[key] = value;
 

--- a/component/background/UserService.tsx
+++ b/component/background/UserService.tsx
@@ -10,29 +10,14 @@ class UserService implements IUserService {
     this.myself = allUsers.child(this.id);
   }
 
-  public getUser(userID: string): Promise<any> {
-    return this.getDataAtReference(allUsers.child(userID));
+  public getUser(userID: string): firebase.database.Reference {
+    return allUsers.child(userID);
   }
 
-  public getMySelf(): Promise<any> {
-    return this.getDataAtReference(this.myself);
+  public getMySelf(): firebase.database.Reference {
+    return this.myself;
   }
 
-  public updateConf(confData: any): void {
-    this.myself.update(confData);
-  }
-
-  public setConf(confData: any): void {
-    this.myself.set(confData);
-  }
-
-  private getDataAtReference(reference: firebase.database.Reference): Promise<void> {
-    return new Promise<void>((resolve) => {
-      this.myself.once("value", (data) => {
-        resolve(data.val());
-      });
-    });
-  }
 }
 
 export default UserService;

--- a/component/background/UserService.tsx
+++ b/component/background/UserService.tsx
@@ -1,0 +1,38 @@
+import * as firebase from "firebase";
+import {IUserService} from "../client/backgroundContext";
+
+const allUsers = firebase.database().ref("users");
+
+class UserService implements IUserService {
+  private myself: firebase.database.Reference;
+
+  constructor(private id: string) {
+    this.myself = allUsers.child(this.id);
+  }
+
+  public getUser(userID: string): Promise<any> {
+    return this.getDataAtReference(allUsers.child(userID));
+  }
+
+  public getMySelf(): Promise<any> {
+    return this.getDataAtReference(this.myself);
+  }
+
+  public updateConf(confData: any): void {
+    this.myself.update(confData);
+  }
+
+  public setConf(confData: any): void {
+    this.myself.set(confData);
+  }
+
+  private getDataAtReference(reference: firebase.database.Reference): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.myself.once("value", (data) => {
+        resolve(data.val());
+      });
+    });
+  }
+}
+
+export default UserService;

--- a/component/background/background.tsx
+++ b/component/background/background.tsx
@@ -1,7 +1,7 @@
 import {STORAGE_KEY_ID} from "../client/Constants";
 import RoomService from "./RoomService";
-import UserService from "./UserService";
 import StorageService from "./StorageService";
+import UserService from "./UserService";
 
 const backgroundService = new StorageService();
 (window as any).backgroundStorageService = backgroundService;

--- a/component/background/background.tsx
+++ b/component/background/background.tsx
@@ -1,5 +1,6 @@
 import {STORAGE_KEY_ID} from "../client/Constants";
 import RoomService from "./RoomService";
+import UserService from "./UserService";
 import StorageService from "./StorageService";
 
 const backgroundService = new StorageService();
@@ -7,4 +8,5 @@ const backgroundService = new StorageService();
 backgroundService.get(STORAGE_KEY_ID)
   .then((id) => {
     (window as any).room = new RoomService(id);
+    (window as any).user = new UserService(id);
   });

--- a/component/client/Constants.tsx
+++ b/component/client/Constants.tsx
@@ -6,6 +6,7 @@ export const SETTING_LINK = "/setting";
 
 export const NOOP_USERNAME = "alphaUser";
 export const NOOP_URL = "https://www.google.com/";
+export const NOOP_ID = "noopID";
 
 export const STORAGE_KEY_INITIALIZED = "initialized";
 export const STORAGE_KEY_USERNAME = "username";

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -1,3 +1,5 @@
+import * as firebase from "firebase";
+
 const backgroundContext: any = chrome.extension.getBackgroundPage();
 
 export interface IRoomService {
@@ -62,26 +64,18 @@ export interface IStorageService {
 }
 
 export interface IUserService {
-  /**
-   * @param userID the userID of the user data to get
-   * @return the promise for the user config of this user
-   */
-  getUser(userID: string): Promise<any>;
 
   /**
-   * @return the promise for the user config of myself
+   * @param userID
+   * @return firebase reference for this user
    */
-  getMySelf(): Promise<any>;
+  getUser(userID: string): firebase.database.Reference;
 
   /**
-   * @param confData the part of configs to update
+   * @return firebase reference for myself
    */
-  updateConf(confData: any);
-
-  /**
-   * @param confData the new configs to override existing config
-   */
-  setConf(confData: any);
+  getMySelf(): firebase.database.Reference;
+  
 }
 
 export const storage: IStorageService = backgroundContext.backgroundStorageService;

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -1,7 +1,61 @@
 const backgroundContext: any = chrome.extension.getBackgroundPage();
 
-export const storage = backgroundContext.backgroundStorageService;
-export const room = backgroundContext.room;
+export interface IRoomService {
+  setUrl(url: string, onMessagePosted: (data: any, from: any) => void);
+  close();
+  pushMessage(data: any);
+  getUser(userID: string);
+  getMySelf();
+  updateConf(confData: any);
+  setConf(confData: any);
+}
+
+
+export interface IStorageService {
+  /**
+   * Clear the storage space and load with default settings
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after defaults are set
+   */
+  reset(): Promise<any>
+
+  /**
+   * Retrieves the stored value for the specified key
+   * @param key The key to look up
+   * @return {Promise<String>} The value associated with the key; undefined if not found
+   */
+  get(key: string): Promise<string>;
+
+  /**
+   * Sets the key-value in the storage
+   * @param key The key
+   * @param value The value
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the value is set
+   */
+  set(key: string, value: string): Promise<any>;
+
+  /**
+   * Removes the key (and its associated value) from the storage
+   * @param key The key to remove
+   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the key is removed
+   */
+  remove(key): Promise<any>;
+
+  /**
+   * Subscribes a callback to an onChanged event.
+   * @param callback The function that takes one parameter of data.
+   */
+  subscribe(callback);
+
+  /**
+   * Unsubscribes a callback from the onChanged event.
+   * @param callback The function that takes one parameter of data.
+   */
+  unsubscribe(callback);
+};
+
+
+export const storage:IStorageService = backgroundContext.backgroundStorageService;
+export const room:IRoomService = backgroundContext.room;
 
 addEventListener("unload", (event) => {
   room.close();

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -14,9 +14,9 @@ export interface IRoomService {
 export interface IStorageService {
   /**
    * Clear the storage space and load with default settings
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after defaults are set
+   * @return {Promise<void>} A promise whose resolve takes no argument, which runs after defaults are set
    */
-  reset(): Promise<any>
+  reset(): Promise<void>
 
   /**
    * Retrieves the stored value for the specified key
@@ -29,16 +29,16 @@ export interface IStorageService {
    * Sets the key-value in the storage
    * @param key The key
    * @param value The value
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the value is set
+   * @return {Promise<void>} A promise whose resolve takes no argument, which runs after the value is set
    */
-  set(key: string, value: string): Promise<any>;
+  set(key: string, value: string): Promise<void>;
 
   /**
    * Removes the key (and its associated value) from the storage
    * @param key The key to remove
-   * @return {Promise<any>} A promise whose resolve takes no argument, which runs after the key is removed
+   * @return {Promise<void>} A promise whose resolve takes no argument, which runs after the key is removed
    */
-  remove(key): Promise<any>;
+  remove(key): Promise<void>;
 
   /**
    * Subscribes a callback to an onChanged event.

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -75,7 +75,7 @@ export interface IUserService {
    * @return firebase reference for myself
    */
   getMySelf(): firebase.database.Reference;
-  
+
 }
 
 export const storage: IStorageService = backgroundContext.backgroundStorageService;

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -10,13 +10,12 @@ export interface IRoomService {
   setConf(confData: any);
 }
 
-
 export interface IStorageService {
   /**
    * Clear the storage space and load with default settings
    * @return {Promise<void>} A promise whose resolve takes no argument, which runs after defaults are set
    */
-  reset(): Promise<void>
+  reset(): Promise<void>;
 
   /**
    * Retrieves the stored value for the specified key
@@ -51,11 +50,10 @@ export interface IStorageService {
    * @param callback The function that takes one parameter of data.
    */
   unsubscribe(callback);
-};
+}
 
-
-export const storage:IStorageService = backgroundContext.backgroundStorageService;
-export const room:IRoomService = backgroundContext.room;
+export const storage: IStorageService = backgroundContext.backgroundStorageService;
+export const room: IRoomService = backgroundContext.room;
 
 addEventListener("unload", (event) => {
   room.close();

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -1,8 +1,21 @@
 const backgroundContext: any = chrome.extension.getBackgroundPage();
 
 export interface IRoomService {
+  /**
+   * set the url and callback listener.
+   * @param url the url of chat room to listen for
+   * @param onMessagePosted callback listener
+   */
   setUrl(url: string, onMessagePosted: (data: any, from: any) => void);
+
+  /**
+   * close the room, and release the listener
+   */
   close();
+
+  /**
+   * @param data the data to be sent in this room
+   */
   pushMessage(data: any);
 }
 
@@ -49,17 +62,31 @@ export interface IStorageService {
 }
 
 export interface IUserService {
+  /**
+   * @param userID the userID of the user data to get
+   * @return the promise for the user config of this user
+   */
   getUser(userID: string): Promise<any>;
 
+  /**
+   * @return the promise for the user config of myself
+   */
   getMySelf(): Promise<any>;
 
+  /**
+   * @param confData the part of configs to update
+   */
   updateConf(confData: any);
 
+  /**
+   * @param confData the new configs to override existing config
+   */
   setConf(confData: any);
 }
 
 export const storage: IStorageService = backgroundContext.backgroundStorageService;
 export const room: IRoomService = backgroundContext.room;
+export const user: IUserService = backgroundContext.user;
 
 addEventListener("unload", (event) => {
   room.close();

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -31,9 +31,9 @@ export interface IStorageService {
   /**
    * Retrieves the stored value for the specified key
    * @param key The key to look up
-   * @return {Promise<String>} The value associated with the key; undefined if not found
+   * @return {Promise<any>} The value associated with the key; undefined if not found
    */
-  get(key: string): Promise<string>;
+  get(key: string): Promise<any>;
 
   /**
    * Sets the key-value in the storage
@@ -41,7 +41,7 @@ export interface IStorageService {
    * @param value The value
    * @return {Promise<void>} A promise whose resolve takes no argument, which runs after the value is set
    */
-  set(key: string, value: string): Promise<void>;
+  set(key: string, value: any): Promise<void>;
 
   /**
    * Removes the key (and its associated value) from the storage

--- a/component/client/backgroundContext.tsx
+++ b/component/client/backgroundContext.tsx
@@ -4,10 +4,6 @@ export interface IRoomService {
   setUrl(url: string, onMessagePosted: (data: any, from: any) => void);
   close();
   pushMessage(data: any);
-  getUser(userID: string);
-  getMySelf();
-  updateConf(confData: any);
-  setConf(confData: any);
 }
 
 export interface IStorageService {
@@ -50,6 +46,16 @@ export interface IStorageService {
    * @param callback The function that takes one parameter of data.
    */
   unsubscribe(callback);
+}
+
+export interface IUserService {
+  getUser(userID: string): Promise<any>;
+
+  getMySelf(): Promise<any>;
+
+  updateConf(confData: any);
+
+  setConf(confData: any);
 }
 
 export const storage: IStorageService = backgroundContext.backgroundStorageService;

--- a/component/client/chat/ChatHistory.tsx
+++ b/component/client/chat/ChatHistory.tsx
@@ -6,8 +6,8 @@ import IData from "./IData";
 import Message from "./Message";
 
 interface IHistoryProps {
-  user: string;
   messages: IData[];
+  userID: string;
 }
 
 class ChatHistory extends React.Component<IHistoryProps, any> {
@@ -30,7 +30,7 @@ class ChatHistory extends React.Component<IHistoryProps, any> {
 
     const messages = this.props.messages.map((data, index) => (
         <ListGroup key={index + data.userFrom + data.message} style={listGroupStyle} >
-          <Message user={this.props.user} username={data.userFrom} message={data.message} index={index} />
+          <Message username={data.userFrom} message={data.message} index={index} userFromID={data.userFromID} userID={this.props.userID} />
         </ListGroup> ));
     return (
       <div style={{overflow: "auto", height: "268px", minHeight: "268px", maxHeight: "268px"}} onScroll={this.handleScroll}>

--- a/component/client/chat/ClientChat.tsx
+++ b/component/client/chat/ClientChat.tsx
@@ -47,7 +47,7 @@ class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
     this.state = {
       messages : []
     };
-    room.setUrl(url, (data: IData, fromUserID) => {
+    room.setUrl(url, (data: IData) => {
       this.setState((prevState, props) => {
         const updatedMessages = prevState.messages.concat(data);
         return Object.assign({}, prevState, {messages: updatedMessages});

--- a/component/client/chat/ClientChat.tsx
+++ b/component/client/chat/ClientChat.tsx
@@ -12,6 +12,7 @@ interface IClientChatState {
 interface IClientChatProps {
   username: string;
   url: string;
+  userID: string;
 }
 
 class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
@@ -37,7 +38,7 @@ class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
     return (
       <div>
         <Panel header={`Chat at  ${this.props.url}`} bsStyle="primary" footer={this.messenger}>
-          <ChatHistory user={this.props.username} messages={this.state.messages} />
+          <ChatHistory messages={this.state.messages} userID={this.props.userID} />
         </Panel>
       </div>
     );
@@ -48,7 +49,7 @@ class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
       messages : []
     };
     room.setUrl(url, (data: IData) => {
-      this.setState((prevState, props) => {
+      this.setState((prevState: IClientChatState, props: IClientChatProps) => {
         const updatedMessages = prevState.messages.concat(data);
         return Object.assign({}, prevState, {messages: updatedMessages});
       });
@@ -56,7 +57,7 @@ class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
   }
 
   private handleSend(message: string): void {
-    room.pushMessage({userFrom: this.props.username, message});
+    room.pushMessage({userFrom: this.props.username, userFromID: this.props.userID, message});
   }
 }
 

--- a/component/client/chat/ClientChat.tsx
+++ b/component/client/chat/ClientChat.tsx
@@ -47,7 +47,7 @@ class ClientChat extends React.Component<IClientChatProps, IClientChatState> {
     this.state = {
       messages : []
     };
-    room.setUrl(url, (data: IData, user) => {
+    room.setUrl(url, (data: IData, fromUserID) => {
       this.setState((prevState, props) => {
         const updatedMessages = prevState.messages.concat(data);
         return Object.assign({}, prevState, {messages: updatedMessages});

--- a/component/client/chat/ClientIndependentChatRoom.tsx
+++ b/component/client/chat/ClientIndependentChatRoom.tsx
@@ -9,6 +9,7 @@ import {storage} from "../backgroundContext";
 interface IClientIndependentChatRoomState {
   username: string;
   currentUrl: string;
+  userID: string;
 }
 
 class ClientIndependentChatRoom extends React.Component<any, IClientIndependentChatRoomState> {
@@ -22,21 +23,24 @@ class ClientIndependentChatRoom extends React.Component<any, IClientIndependentC
     super();
     this.state = {
       currentUrl: Constants.NOOP_URL,
-      username: Constants.NOOP_USERNAME
+      username: Constants.NOOP_USERNAME,
+      userID: Constants.NOOP_ID
     };
-    storage.get("username")
-      .then((username) => {
+    storage.get(Constants.STORAGE_KEY_USERNAME).then((username) => {
+      storage.get(Constants.STORAGE_KEY_ID).then((userID) => {
         ClientIndependentChatRoom.getCurrentTabUrl((url) => {
           this.setState({
             currentUrl: (url) ? url : Constants.NOOP_URL,
-            username: (username) ? username : Constants.NOOP_USERNAME
+            username: (username) ? username : Constants.NOOP_USERNAME,
+            userID: (userID) ? userID : Constants.NOOP_ID
           });
         });
       });
+    });
   }
 
   public render() {
-    return <ClientChat url={this.state.currentUrl} username={this.state.username}/>;
+    return <ClientChat url={this.state.currentUrl} username={this.state.username} userID={this.state.userID}/>;
   }
 }
 

--- a/component/client/chat/ClientIndependentChatRoom.tsx
+++ b/component/client/chat/ClientIndependentChatRoom.tsx
@@ -7,9 +7,9 @@ import * as Constants from "../Constants";
 import {storage} from "../backgroundContext";
 
 interface IClientIndependentChatRoomState {
-  username: string;
   currentUrl: string;
   userID: string;
+  username: string;
 }
 
 class ClientIndependentChatRoom extends React.Component<any, IClientIndependentChatRoomState> {
@@ -23,16 +23,16 @@ class ClientIndependentChatRoom extends React.Component<any, IClientIndependentC
     super();
     this.state = {
       currentUrl: Constants.NOOP_URL,
-      username: Constants.NOOP_USERNAME,
-      userID: Constants.NOOP_ID
+      userID: Constants.NOOP_ID,
+      username: Constants.NOOP_USERNAME
     };
     storage.get(Constants.STORAGE_KEY_USERNAME).then((username) => {
       storage.get(Constants.STORAGE_KEY_ID).then((userID) => {
         ClientIndependentChatRoom.getCurrentTabUrl((url) => {
           this.setState({
             currentUrl: (url) ? url : Constants.NOOP_URL,
-            username: (username) ? username : Constants.NOOP_USERNAME,
-            userID: (userID) ? userID : Constants.NOOP_ID
+            userID: (userID) ? userID : Constants.NOOP_ID,
+            username: (username) ? username : Constants.NOOP_USERNAME
           });
         });
       });

--- a/component/client/chat/ClientIndependentChatRoom.tsx
+++ b/component/client/chat/ClientIndependentChatRoom.tsx
@@ -26,19 +26,13 @@ class ClientIndependentChatRoom extends React.Component<any, IClientIndependentC
     };
     storage.get("username")
       .then((username) => {
-        if (username) {
+        ClientIndependentChatRoom.getCurrentTabUrl((url) => {
           this.setState({
-            username
+            currentUrl: (url) ? url : Constants.NOOP_URL,
+            username: (username) ? username : Constants.NOOP_USERNAME
           });
-        }
-      });
-    ClientIndependentChatRoom.getCurrentTabUrl((url) => {
-      if (url) {
-        this.setState({
-          currentUrl: url
         });
-      }
-    });
+      });
   }
 
   public render() {

--- a/component/client/chat/IData.tsx
+++ b/component/client/chat/IData.tsx
@@ -1,5 +1,6 @@
 interface IData {
   userFrom: string;
+  userFromID: string;
   message: string;
 }
 

--- a/component/client/chat/Message.tsx
+++ b/component/client/chat/Message.tsx
@@ -23,12 +23,11 @@ class Message extends React.Component<IMessageProps, any> {
       color: fontColor
     };
     const contextID = this.props.index + this.props.username;
-    const isSelf = this.props.userFromID === this.props.userID;
 
     return (
       <div>
-        <ContextMenuTrigger id={contextID} disable={isSelf}>
-          <div onContextMenu={(event) => {if (isSelf) event.preventDefault()}}>
+        <ContextMenuTrigger id={contextID} disable={this.props.userFromID === this.props.userID}>
+          <div onContextMenu={this.handleContextMenu}>
             <ListGroupItem bsStyle="info" style={messageStyle}>
               <Grid>
                 <Row>
@@ -56,6 +55,10 @@ class Message extends React.Component<IMessageProps, any> {
   private startPrivateChat(event, data) {
     event.preventDefault();
     console.log("[ INFO ] : Context Menu Click: ", data);
+  }
+
+  private handleContextMenu(event) {
+    if (this.props.userFromID === this.props.userID) event.preventDefault();
   }
 
   /*

--- a/component/client/chat/Message.tsx
+++ b/component/client/chat/Message.tsx
@@ -13,6 +13,8 @@ interface IMessageProps {
 class Message extends React.Component<IMessageProps, any> {
   constructor(props: IMessageProps) {
     super(props);
+
+    this.handleContextMenu = this.handleContextMenu.bind(this);
   }
 
   public render(): JSX.Element {

--- a/component/client/chat/Message.tsx
+++ b/component/client/chat/Message.tsx
@@ -3,10 +3,11 @@ import {Col, Grid, ListGroupItem, Row} from "react-bootstrap";
 import {ContextMenu, ContextMenuTrigger, MenuItem} from "react-contextmenu";
 
 interface IMessageProps {
-  user: string;
   username: string;
   message: string;
   index: number;
+  userFromID: string;
+  userID: string;
 }
 
 class Message extends React.Component<IMessageProps, any> {
@@ -25,7 +26,7 @@ class Message extends React.Component<IMessageProps, any> {
 
     return (
       <div>
-        <ContextMenuTrigger id={contextIdentifier} disable={this.props.user === this.props.username}>
+        <ContextMenuTrigger id={contextIdentifier} disable={this.props.userFromID === this.props.userID}>
           <div>
             <ListGroupItem bsStyle="info" style={messageStyle}>
               <Grid>

--- a/component/client/chat/Message.tsx
+++ b/component/client/chat/Message.tsx
@@ -22,12 +22,13 @@ class Message extends React.Component<IMessageProps, any> {
       backgroundColor: `${backgroundColor}`, // FIXME: I should not need to do this to the linter.
       color: fontColor
     };
-    const contextIdentifier = this.props.index + this.props.username;
+    const contextID = this.props.index + this.props.username;
+    const isSelf = this.props.userFromID === this.props.userID;
 
     return (
       <div>
-        <ContextMenuTrigger id={contextIdentifier} disable={this.props.userFromID === this.props.userID}>
-          <div>
+        <ContextMenuTrigger id={contextID} disable={isSelf}>
+          <div onContextMenu={(event) => {if (isSelf) event.preventDefault()}}>
             <ListGroupItem bsStyle="info" style={messageStyle}>
               <Grid>
                 <Row>
@@ -43,7 +44,7 @@ class Message extends React.Component<IMessageProps, any> {
           </div>
         </ContextMenuTrigger>
 
-        <ContextMenu id={contextIdentifier}>
+        <ContextMenu id={contextID}>
           <MenuItem data={{user: this.props.username}} onClick={this.startPrivateChat}>
             Private Chat with {this.props.username}
           </MenuItem>

--- a/component/client/core/ClientCore.tsx
+++ b/component/client/core/ClientCore.tsx
@@ -24,7 +24,7 @@ class ClientCore extends React.Component<any, ClientCoreState> {
 
     // Only change initialize status if setting is found.
     storage.get(STORAGE_KEY_INITIALIZED).then((hasInitalized) => {
-      if (hasInitalized) this.setState({initialized: hasInitalized});
+      if (hasInitalized) this.setState({initialized: hasInitalized === "true"});
     });
 
     this.handleInit = this.handleInit.bind(this);
@@ -101,8 +101,8 @@ class ClientCore extends React.Component<any, ClientCoreState> {
 
   private handleSave(): void {
     storage.set(STORAGE_KEY_USERNAME, this.state.username)
-    .then(storage.set(STORAGE_KEY_INITIALIZED, true)
-      .then(this.setState({initialized: true, username: ""})));
+      .then(() => storage.set(STORAGE_KEY_INITIALIZED, "true")
+        .then(() => this.setState({initialized: true, username: ""})));
   }
 
   private handleInit(data, area: string): void {

--- a/component/client/core/ClientCore.tsx
+++ b/component/client/core/ClientCore.tsx
@@ -12,6 +12,8 @@ interface ClientCoreState {
 }
 
 class ClientCore extends React.Component<any, ClientCoreState> {
+  private storageListenerUnsubscriber: () => void;
+
   constructor(props: any) {
     super(props);
 
@@ -27,16 +29,18 @@ class ClientCore extends React.Component<any, ClientCoreState> {
       if (hasInitalized) this.setState({initialized: hasInitalized});
     });
 
-    this.handleInit = this.handleInit.bind(this);
-    storage.subscribe(this.handleInit);
-
     this.handleUsernameChange = this.handleUsernameChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleSave = this.handleSave.bind(this);
   }
 
+  public componentDidMount() {
+    this.handleInit = this.handleInit.bind(this);
+    this.storageListenerUnsubscriber = storage.subscribe(this.handleInit);
+  }
+
   public componentWillUnmount() {
-    storage.unsubscribe(this.handleInit);
+    this.storageListenerUnsubscriber();
   }
 
   public render(): JSX.Element {
@@ -105,8 +109,8 @@ class ClientCore extends React.Component<any, ClientCoreState> {
         .then(() => this.setState({initialized: true, username: ""})));
   }
 
-  private handleInit(data, area: string): void {
-    if (area === "sync" && data.initialized) {
+  private handleInit(data): void {
+    if (data.initialized) {
       this.setState({initialized: data.initialized.newValue});
     }
   }

--- a/component/client/core/ClientCore.tsx
+++ b/component/client/core/ClientCore.tsx
@@ -24,7 +24,7 @@ class ClientCore extends React.Component<any, ClientCoreState> {
 
     // Only change initialize status if setting is found.
     storage.get(STORAGE_KEY_INITIALIZED).then((hasInitalized) => {
-      if (hasInitalized) this.setState({initialized: hasInitalized === "true"});
+      if (hasInitalized) this.setState({initialized: hasInitalized});
     });
 
     this.handleInit = this.handleInit.bind(this);
@@ -101,7 +101,7 @@ class ClientCore extends React.Component<any, ClientCoreState> {
 
   private handleSave(): void {
     storage.set(STORAGE_KEY_USERNAME, this.state.username)
-      .then(() => storage.set(STORAGE_KEY_INITIALIZED, "true")
+      .then(() => storage.set(STORAGE_KEY_INITIALIZED, true)
         .then(() => this.setState({initialized: true, username: ""})));
   }
 

--- a/component/client/settings/ClientSetting.tsx
+++ b/component/client/settings/ClientSetting.tsx
@@ -122,7 +122,6 @@ class ClientSetting extends React.Component<any, IClientSettingState> {
   }
 
   private handleReload(data): void {
-    console.log("[ INFO ] : handleReload data", data);
     if (data.username) {
       this.setState((prevState: IClientSettingState, props: any) => {
         const usernameField = {username: {

--- a/component/client/settings/ClientSetting.tsx
+++ b/component/client/settings/ClientSetting.tsx
@@ -144,7 +144,7 @@ class ClientSetting extends React.Component<any, IClientSettingState> {
 
   private reset() {
     storage.reset().then(() => {
-      storage.set(STORAGE_KEY_INITIALIZED, false);
+      storage.set(STORAGE_KEY_INITIALIZED, "false");
       this.reloadSettings();
     });
   }


### PR DESCRIPTION
~~This attempts to reduce the `setState` call to `render`. We should not need to call `setState` in 2 separate cases if the core of the client will not properly function with all of the data.~~
It now attempts to delay rendering until critical data is loaded rather than load multiple times as critical data becomes available. Previously, this lead to many potential errors flagged in the console due to the variance of the data being retrieved from `chrome.storage`. 

It also attempts to improve the user experience when dealing with context menus. Context menus no longer rely on the `username` of the user and the message creator. Rather, it now relies on the more reliable `userID`.

It also fixes a critical bug with `username`. With the right sequence of events, the `this.state.dirty` could be tricked into an always `true` state.

Lastly, the `StorageService`'s subscribe method has been rebuilt and modeled after `redux` and `reflux` stores. It will now return the thunk to unsubscribe the callback from the store's listener. Callbacks can now be single argument functions that take some data object. The work of filtering events has been done by the subscribe method.